### PR TITLE
Throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]max_multiplot_metrics` - Default is `10`.
 * `[grinder.bf.]name_fmt` - Default is `org.example.metric.%d`.
 
+* `[grinder.bf.]throttling_group.<name>.max_requests_per_minute` - Create a throttling group with the given `name`. The value of the property is taken as the throttling group's `max_requests_per_minute` parameter. By default, no throttling groups are created if no properties are specified.
+
 * `[grinder.bf.]ingest_weight` - Default is `15`.
 * `[grinder.bf.]ingest_num_tenants` - Ingestion threads randomly generate a numerical tenant id in the range of `[0,ingest_num_tenants)`. Change this property to control how many different tenant id's are used when sending standard metrics to the service. Default is `4`.
 * `[grinder.bf.]ingest_metrics_per_tenant` - Ingestion threads randomly generate a numerical metric name suffix in the range of `[0,ingest_metrics_per_tenant)`. Metric names will generally be of the form `org.example.metric.%d`, or whatever the `name_fmt` property is set to. Change this property to control how many different metrics will have data generated for them. Default is `15`.
 * `[grinder.bf.]ingest_batch_size` - Ingestion threads will generate this many metrics in a single payload (HTTP request body). Default is `5`.
 * `[grinder.bf.]ingest_delay_millis` - Configures delayed metrics. Default is `""`, which doesn't produced any delayed metrics.
+* `[grinder.bf.]ingest_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `IngestThread` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 * `[grinder.bf.]enum_weight` - Default is `0`. NOTE: Enums are deprecated and will be removed in the future.
 * `[grinder.bf.]enum_num_tenants` - Exactly like `ingest_num_tenants`, except that this property controls the number of tenant id's for the `EnumIngestThread` class. This property is provided so that ingest and enum ingest threads can be configured independently. Default is `4.`
@@ -57,12 +60,16 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]annotations_weight` - Default is `5`.
 * `[grinder.bf.]annotations_num_tenants` - Exactly like `ingest_num_tenants`, except that this property controls the number of tenant id's for the `AnnotationsIngestThread` class. This property is provided so that ingest and annotation ingest threads can be configured independently. Default is `5`.
 * `[grinder.bf.]annotations_per_tenant` - Exactly like `ingest_metrics_per_tenant`, except that this property controls the number of metric name suffixes for the `AnnotationsIngestThread` class. This property is provided so that ingest and enum ingest threads can be configured independently. Default is `10`.
+* `[grinder.bf.]annotations_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `AnnotationsIngestThread` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 * `[grinder.bf.]singleplot_query_weight` - Default is `10`.
+* `[grinder.bf.]singleplot_query_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `SinglePlotQuery` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 * `[grinder.bf.]multiplot_query_weight` - Default is `10`.
+* `[grinder.bf.]multiplot_query_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `MultiPlotQuery` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 * `[grinder.bf.]search_query_weight` - Default is `10`.
+* `[grinder.bf.]search_query_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `SearchQuery` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 * `[grinder.bf.]enum_search_query_weight` - Default is `0`. NOTE: Enums are deprecated and will be removed in the future.
 
@@ -71,6 +78,7 @@ Grinder-specific properties are discussed in more detail [here](http://grinder.s
 * `[grinder.bf.]enum_multiplot_query_weight` - Default is `0`. NOTE: Enums are deprecated and will be removed in the future.
 
 * `[grinder.bf.]annotations_query_weight` - Default is `8`.
+* `[grinder.bf.]annotations_query_throttling_group` - Name of an above-defined throttling group. The named tgroup will be assigned to all `AnnotationsQuery` objects. Default is `None`. If the tgroup name is blank, or is not defined amongh the throttling groups (or if there is a _spelling_error_), then no throttling will be performed for this thread type.
 
 
 

--- a/properties/grinder.properties.local
+++ b/properties/grinder.properties.local
@@ -12,9 +12,6 @@ grinder.bf.query_url="http://localhost:20000"
 grinder.bf.max_multiplot_metrics=10
 grinder.bf.name_fmt="org.example.metric.%d"
 
-#grinder.bf.throttling_group.ingest.max_requests_per_minute=100000000
-#grinder.bf.throttling_group.query.max_requests_per_minute=100000000
-
 grinder.bf.ingest_weight=15
 grinder.bf.ingest_num_tenants=4
 grinder.bf.ingest_metrics_per_tenant=15

--- a/properties/grinder.properties.local
+++ b/properties/grinder.properties.local
@@ -12,10 +12,14 @@ grinder.bf.query_url="http://localhost:20000"
 grinder.bf.max_multiplot_metrics=10
 grinder.bf.name_fmt="org.example.metric.%d"
 
+#grinder.bf.throttling_group.ingest.max_requests_per_minute=100000000
+#grinder.bf.throttling_group.query.max_requests_per_minute=100000000
+
 grinder.bf.ingest_weight=15
 grinder.bf.ingest_num_tenants=4
 grinder.bf.ingest_metrics_per_tenant=15
 grinder.bf.ingest_batch_size=5
+grinder.bf.ingest_throttling_group=ingest
 
 
 grinder.bf.enum_ingest_weight=0
@@ -26,12 +30,16 @@ grinder.bf.enum_batch_size=5
 grinder.bf.annotations_weight=5
 grinder.bf.annotations_num_tenants=4
 grinder.bf.annotations_per_tenant=1
+grinder.bf.annotations_throttling_group=ingest
 
 grinder.bf.singleplot_query_weight=10
+grinder.bf.singleplot_query_throttling_group=query
 
 grinder.bf.multiplot_query_weight=10
+grinder.bf.multiplot_query_throttling_group=query
 
 grinder.bf.search_query_weight=10
+grinder.bf.search_query_throttling_group=query
 
 grinder.bf.enum_search_query_weight=0
 
@@ -40,3 +48,4 @@ grinder.bf.enum_single_plot_query_weight=0
 grinder.bf.enum_multiplot_query_weight=0
 
 grinder.bf.annotations_query_weight=10
+grinder.bf.annotations_query_throttling_group=query

--- a/run-unit-tests-with-coverage.sh
+++ b/run-unit-tests-with-coverage.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-coverage run --source=abstract_thread,annotationsingest,ingest,ingestenum,query,thread_manager,config scripts/tests.py
+coverage run --source=abstract_thread,annotationsingest,ingest,ingestenum,query,thread_manager,config,throttling_group scripts/tests.py
 coverage html
 

--- a/scripts/abstract_thread.py
+++ b/scripts/abstract_thread.py
@@ -50,15 +50,20 @@ class AbstractThread(object):
     def make_request(self, logger, time):
         raise Exception("Can't create abstract thread")
 
-    def __init__(self, thread_num, agent_num, request, config):
+    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
 
         self.thread_num = thread_num
         self.agent_num = agent_num
         self.request = request
+        self.tgroup = tgroup
 
         self.config = default_config.copy()
         if config:
             self.config.update(config)
+
+    def count_request(self):
+        if self.tgroup is not None:
+            self.tgroup.count_request()
 
     @classmethod
     def time(cls):

--- a/scripts/abstract_thread.py
+++ b/scripts/abstract_thread.py
@@ -3,6 +3,8 @@
 import random
 import time
 
+from throttling_group import NullThrottlingGroup
+
 default_config = {
     'url': "http://localhost:19000",
     'query_url': "http://localhost:20000",
@@ -50,7 +52,8 @@ class AbstractThread(object):
     def make_request(self, logger, time):
         raise Exception("Can't create abstract thread")
 
-    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
+    def __init__(self, thread_num, agent_num, request, config,
+                 tgroup=NullThrottlingGroup()):
 
         self.thread_num = thread_num
         self.agent_num = agent_num
@@ -62,8 +65,7 @@ class AbstractThread(object):
             self.config.update(config)
 
     def count_request(self):
-        if self.tgroup is not None:
-            self.tgroup.count_request()
+        self.tgroup.count_request()
 
     @classmethod
     def time(cls):

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -29,9 +29,11 @@ class AnnotationsIngestThread(AbstractThread):
 
     def make_request(self, logger, time, tenant_id=None, metric_id=None):
         if tenant_id is None:
-            tenant_id = random.randint(1, self.config['annotations_num_tenants'])
+            tenant_id = random.randint(
+                1, self.config['annotations_num_tenants'])
         if metric_id is None:
-            metric_id = random.randint(1, self.config['annotations_per_tenant'])
+            metric_id = random.randint(
+                1, self.config['annotations_per_tenant'])
         payload = self.generate_payload(time, metric_id)
 
         self.count_request()

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -9,9 +9,9 @@ from abstract_thread import AbstractThread, generate_metric_name
 
 
 class AnnotationsIngestThread(AbstractThread):
-    def __init__(self, thread_num, agent_num, request, config, trgoup=None):
+    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
         AbstractThread.__init__(self, thread_num, agent_num, request, config,
-                                trgoup)
+                                tgroup)
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -6,10 +6,12 @@ try:
 except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
+from throttling_group import NullThrottlingGroup
 
 
 class AnnotationsIngestThread(AbstractThread):
-    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
+    def __init__(self, thread_num, agent_num, request, config,
+                 tgroup=NullThrottlingGroup()):
         AbstractThread.__init__(self, thread_num, agent_num, request, config,
                                 tgroup)
 

--- a/scripts/annotationsingest.py
+++ b/scripts/annotationsingest.py
@@ -9,8 +9,9 @@ from abstract_thread import AbstractThread, generate_metric_name
 
 
 class AnnotationsIngestThread(AbstractThread):
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
+    def __init__(self, thread_num, agent_num, request, config, trgoup=None):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config,
+                                trgoup)
 
     def generate_annotation(self, time, metric_id):
         metric_name = generate_metric_name(metric_id, self.config)
@@ -33,5 +34,6 @@ class AnnotationsIngestThread(AbstractThread):
             metric_id = random.randint(1, self.config['annotations_per_tenant'])
         payload = self.generate_payload(time, metric_id)
 
+        self.count_request()
         result = self.request.POST(self.ingest_url(tenant_id), payload)
         return result

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -53,11 +53,13 @@ requests_by_type = {
     AnnotationsQuery: create_request_obj(6, "AnnotationsQuery"),
 }
 
+config = abstract_thread.default_config.copy()
+config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
+thread_manager = tm.ThreadManager(config, requests_by_type)
+
+
 class TestRunner:
     def __init__(self):
-        config = abstract_thread.default_config.copy()
-        config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
-        thread_manager = tm.ThreadManager(config, requests_by_type)
         agent_number = grinder.getAgentNumber()
         self.thread = thread_manager.setup_thread(
             grinder.getThreadNumber(), agent_number)

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -1,4 +1,6 @@
 
+import re
+
 from net.grinder.script.Grinder import grinder
 from net.grinder.script import Test
 from net.grinder.plugin.http import HTTPRequest
@@ -13,6 +15,7 @@ from query import EnumSearchQuery, EnumSinglePlotQuery, AnnotationsQuery
 from query import EnumMultiPlotQuery
 from config import clean_configs
 import abstract_thread
+from throttling_group import ThrottlingGroup
 
 # ENTRY POINT into the Grinder
 
@@ -57,12 +60,21 @@ config = abstract_thread.default_config.copy()
 config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
 thread_manager = tm.ThreadManager(config, requests_by_type)
 
+throttling_groups = {}
+for k, v in config.iteritems():
+    m = re.match(
+        '(grinder\.bf\.)?throttling_group\.(\w+)\.max_requests_per_minute',
+        str(k))
+    if m:
+        name = m.groups()[-1]
+        throttling_groups[name] = ThrottlingGroup(name, int(v))
+
 
 class TestRunner:
     def __init__(self):
         agent_number = grinder.getAgentNumber()
         self.thread = thread_manager.setup_thread(
-            grinder.getThreadNumber(), agent_number)
+            grinder.getThreadNumber(), agent_number, throttling_groups)
 
     def __call__(self):
         result = self.thread.make_request(grinder.logger.info,

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -29,23 +29,24 @@ def create_request_obj(test_num, test_name):
     return request
 
 
+requests_by_type = {
+    IngestThread: create_request_obj(1, "Ingest test"),
+    EnumIngestThread: create_request_obj(7, "Enum Ingest test"),
+    AnnotationsIngestThread:
+        create_request_obj(2, "Annotations Ingest test"),
+    SinglePlotQuery: create_request_obj(3, "SinglePlotQuery"),
+    MultiPlotQuery: create_request_obj(4, "MultiPlotQuery"),
+    SearchQuery: create_request_obj(5, "SearchQuery"),
+    EnumSearchQuery: create_request_obj(8, "EnumSearchQuery"),
+    EnumSinglePlotQuery: create_request_obj(9, "EnumSinglePlotQuery"),
+    EnumMultiPlotQuery: create_request_obj(10, "EnumMultiPlotQuery"),
+    AnnotationsQuery: create_request_obj(6, "AnnotationsQuery"),
+}
+
 class TestRunner:
     def __init__(self):
         config = abstract_thread.default_config.copy()
         config.update(clean_configs(py_java.get_config_from_grinder(grinder)))
-        requests_by_type = {
-            IngestThread: create_request_obj(1, "Ingest test"),
-            EnumIngestThread: create_request_obj(7, "Enum Ingest test"),
-            AnnotationsIngestThread:
-                create_request_obj(2, "Annotations Ingest test"),
-            SinglePlotQuery: create_request_obj(3, "SinglePlotQuery"),
-            MultiPlotQuery: create_request_obj(4, "MultiPlotQuery"),
-            SearchQuery: create_request_obj(5, "SearchQuery"),
-            EnumSearchQuery: create_request_obj(8, "EnumSearchQuery"),
-            EnumSinglePlotQuery: create_request_obj(9, "EnumSinglePlotQuery"),
-            EnumMultiPlotQuery: create_request_obj(10, "EnumMultiPlotQuery"),
-            AnnotationsQuery: create_request_obj(6, "AnnotationsQuery"),
-        }
         thread_manager = tm.ThreadManager(config, requests_by_type)
         agent_number = grinder.getAgentNumber()
         self.thread = thread_manager.setup_thread(

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -18,8 +18,18 @@ import abstract_thread
 
 # The code inside the TestRunner class is gets executed by each worker thread
 # Outside the class is executed before any of the workers begin
-
-
+#
+# Module-level code gets run exactly once by the main thread.
+#
+# TestRunner.__init__ gets run once for each worker thread, and is run by that
+# worker thread
+#
+# TestRunner.__call__ gets run `grinder.runs` times by each worker thread, for
+# a total of `grinder.runs` * `grinder.threads` times.
+#
+# Each worker thread gets its own TestRunner instance, and re-uses that
+# instance for all runs
+#
 
 
 def create_request_obj(test_num, test_name):

--- a/scripts/grinder.py
+++ b/scripts/grinder.py
@@ -20,13 +20,11 @@ import abstract_thread
 # Outside the class is executed before any of the workers begin
 
 
-__grinder_tests_by_request_object = {}
 
 
 def create_request_obj(test_num, test_name):
     test = Test(test_num, test_name)
     request = HTTPRequest()
-    __grinder_tests_by_request_object[request] = test
     test.record(request)
     return request
 

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -21,8 +21,9 @@ class IngestThread(AbstractThread):
         5: 'decades'
     }
 
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
+    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config,
+                                tgroup)
 
     def generate_unit(self, tenant_id):
         unit_number = tenant_id % 6
@@ -63,5 +64,6 @@ class IngestThread(AbstractThread):
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
+        self.count_request()
         result = self.request.POST(self.ingest_url(), payload)
         return result

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -58,8 +58,10 @@ class IngestThread(AbstractThread):
         if tenant_metric_id_values is None:
             tenant_metric_id_values = []
             for i in xrange(self.config['ingest_batch_size']):
-                tenant_id = random.randint(1, self.config['ingest_num_tenants'])
-                metric_id = random.randint(1, self.config['ingest_metrics_per_tenant'])
+                tenant_id = random.randint(
+                    1, self.config['ingest_num_tenants'])
+                metric_id = random.randint(
+                    1, self.config['ingest_metrics_per_tenant'])
                 value = random.randint(0, RAND_MAX)
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
+from throttling_group import NullThrottlingGroup
 
 
 RAND_MAX = 982374239
@@ -21,7 +22,8 @@ class IngestThread(AbstractThread):
         5: 'decades'
     }
 
-    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
+    def __init__(self, thread_num, agent_num, request, config,
+                 tgroup=NullThrottlingGroup()):
         AbstractThread.__init__(self, thread_num, agent_num, request, config,
                                 tgroup)
 

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -14,9 +14,9 @@ class EnumIngestThread(AbstractThread):
     def generate_enum_metric_name(metric_id, config):
         return "enum_grinder_" + config['name_fmt'] % metric_id
 
-    def __init__(self, thread_num, agent_num, request, config, trgoup=None):
+    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
         AbstractThread.__init__(self, thread_num, agent_num, request, config,
-                                trgoup)
+                                tgroup)
 
     def generate_enum_suffix(self):
         return "_" + str(random.randint(0, self.config['enum_num_values']))

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     import json
 from abstract_thread import AbstractThread
+from throttling_group import NullThrottlingGroup
 
 
 class EnumIngestThread(AbstractThread):
@@ -14,7 +15,8 @@ class EnumIngestThread(AbstractThread):
     def generate_enum_metric_name(metric_id, config):
         return "enum_grinder_" + config['name_fmt'] % metric_id
 
-    def __init__(self, thread_num, agent_num, request, config, tgroup=None):
+    def __init__(self, thread_num, agent_num, request, config,
+                 tgroup=NullThrottlingGroup()):
         AbstractThread.__init__(self, thread_num, agent_num, request, config,
                                 tgroup)
 

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -14,8 +14,9 @@ class EnumIngestThread(AbstractThread):
     def generate_enum_metric_name(metric_id, config):
         return "enum_grinder_" + config['name_fmt'] % metric_id
 
-    def __init__(self, thread_num, agent_num, request, config):
-        AbstractThread.__init__(self, thread_num, agent_num, request, config)
+    def __init__(self, thread_num, agent_num, request, config, trgoup=None):
+        AbstractThread.__init__(self, thread_num, agent_num, request, config,
+                                trgoup)
 
     def generate_enum_suffix(self):
         return "_" + str(random.randint(0, self.config['enum_num_values']))
@@ -47,5 +48,6 @@ class EnumIngestThread(AbstractThread):
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)
         payload = self.generate_payload(time, tenant_metric_id_values)
+        self.count_request()
         result = self.request.POST(self.ingest_url(), payload)
         return result

--- a/scripts/ingestenum.py
+++ b/scripts/ingestenum.py
@@ -43,7 +43,8 @@ class EnumIngestThread(AbstractThread):
             tenant_metric_id_values = []
             for i in xrange(self.config['enum_batch_size']):
                 tenant_id = random.randint(1, self.config['enum_num_tenants'])
-                metric_id = random.randint(1, self.config['enum_metrics_per_tenant'])
+                metric_id = random.randint(
+                    1, self.config['enum_metrics_per_tenant'])
                 value = 'e_g_' + str(metric_id) + self.generate_enum_suffix()
                 tmv = [tenant_id, metric_id, value]
                 tenant_metric_id_values.append(tmv)

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -13,9 +13,9 @@ class AbstractQuery(AbstractThread):
 
     query_interval_name = None
 
-    def __init__(self, thread_num, agent_number, request, config, trgoup=None):
+    def __init__(self, thread_num, agent_number, request, config, tgroup=None):
         AbstractThread.__init__(self, thread_num, agent_number, request,
-                                config, trgoup)
+                                config, tgroup)
         self.thread_num = thread_num
         self.config = config
         self.request = request

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -13,9 +13,9 @@ class AbstractQuery(AbstractThread):
 
     query_interval_name = None
 
-    def __init__(self, thread_num, agent_number, request, config):
+    def __init__(self, thread_num, agent_number, request, config, trgoup=None):
         AbstractThread.__init__(self, thread_num, agent_number, request,
-                                config)
+                                config, trgoup)
         self.thread_num = thread_num
         self.config = config
         self.request = request
@@ -39,6 +39,7 @@ class SinglePlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, metric_name, frm,
             to, resolution)
+        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -67,6 +68,7 @@ class MultiPlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, frm,
             to, resolution)
+        self.count_request()
         result = self.request.POST(url, payload)
         return result
 
@@ -89,6 +91,7 @@ class SearchQuery(AbstractQuery):
         url = "%s/v2.0/%d/metrics/search?query=%s" % (
             self.config['query_url'],
             tenant_id, metric_regex)
+        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -104,6 +107,7 @@ class AnnotationsQuery(AbstractQuery):
         frm = time - self.one_day
         url = "%s/v2.0/%d/events/getEvents?from=%d&until=%d" % (
             self.config['query_url'], tenant_id, frm, to)
+        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -126,6 +130,7 @@ class EnumSearchQuery(AbstractQuery):
         url = "%s/v2.0/%d/metrics/search?query=%s&include_enum_values=true" % (
             self.config['query_url'],
             tenant_id, metric_regex)
+        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -148,6 +153,7 @@ class EnumSinglePlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, metric_name, frm,
             to, resolution)
+        self.count_request()
         result = self.request.GET(url)
         return result
 
@@ -176,5 +182,6 @@ class EnumMultiPlotQuery(AbstractQuery):
             self.config['query_url'],
             tenant_id, frm,
             to, resolution)
+        self.count_request()
         result = self.request.POST(url, payload)
         return result

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -6,6 +6,7 @@ except ImportError:
     import json
 from abstract_thread import AbstractThread, generate_metric_name
 from ingestenum import EnumIngestThread
+from throttling_group import NullThrottlingGroup
 
 
 class AbstractQuery(AbstractThread):
@@ -13,7 +14,8 @@ class AbstractQuery(AbstractThread):
 
     query_interval_name = None
 
-    def __init__(self, thread_num, agent_number, request, config, tgroup=None):
+    def __init__(self, thread_num, agent_number, request, config,
+                 tgroup=NullThrottlingGroup()):
         AbstractThread.__init__(self, thread_num, agent_number, request,
                                 config, tgroup)
         self.thread_num = thread_num

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -787,6 +787,38 @@ class ThrottlingGroupTest(unittest.TestCase):
         self.assertEquals(1, tg.count)
         self.assertEquals([60 - 2], sleeps)
 
+    def test_count_reset_after_minute_transpires(self):
+        # given
+        times = iter([0, 61]).next
+        last_time_returned = [None]
+        def time_source():
+            # this time source returns a fixed sequence of numbers
+            t = times()
+            last_time_returned[0] = t
+            return t
+        sleeps = []
+        def sleep_source(arg):
+            # this sleep source just logs what arguments were passed to it, and
+            # doesn't actually sleep
+            sleeps.append(arg)
+        tg = ThrottlingGroup('test', 2, time_source=time_source,
+                             sleep_source=sleep_source)
+
+        # when we count the first request
+        tg.count_request()
+
+        # then it increments the count and doesn't sleep
+        self.assertEquals(1, tg.count)
+        self.assertEquals([], sleeps)
+
+        # when we count the second request
+        tg.count_request()
+
+        # then it resets the count to one and doesn't sleep
+        self.assertEquals(1, tg.count)
+        self.assertEquals([], sleeps)
+
+
 
 suite = unittest.TestSuite()
 loader = unittest.TestLoader()

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -318,6 +318,7 @@ class ThreadManagerTest(TestCaseBase):
     def test_setup_thread_invalid_thread_type(self):
         self.assertRaises(Exception, self.tm.setup_thread, (45, 0))
 
+
 class InitProcessTest(TestCaseBase):
     def setUp(self):
         self.test_config = abstract_thread.default_config.copy()
@@ -658,8 +659,7 @@ class MakeQueryRequestsTest(TestCaseBase):
     def test_query_make_SinglePlotQuery_request(self):
         req = requests_by_type[query.SinglePlotQuery]
         qq = query.SinglePlotQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 0,
-                                  'org.example.metric.metric123')
+        result = qq.make_request(None, 1000, 0, 'org.example.metric.metric123')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/0/views/" +
                          "org.example.metric.metric123?from=-86399000&" +
@@ -669,8 +669,7 @@ class MakeQueryRequestsTest(TestCaseBase):
     def test_query_make_SearchQuery_request(self):
         req = requests_by_type[query.SearchQuery]
         qq = query.SearchQuery(0, self.agent_num, req, self.config)
-        result = qq.make_request(None, 1000, 10,
-                                  'org.example.metric.*')
+        result = qq.make_request(None, 1000, 10, 'org.example.metric.*')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/10/metrics/search?" +
                          "query=org.example.metric.*")
@@ -722,7 +721,7 @@ class MakeQueryRequestsTest(TestCaseBase):
         req = requests_by_type[query.EnumSinglePlotQuery]
         qq = query.EnumSinglePlotQuery(0, self.agent_num, req, self.config)
         result = qq.make_request(None, 1000, 50,
-                                  'enum_grinder_org.example.metric.metric456')
+                                 'enum_grinder_org.example.metric.metric456')
         self.assertEqual(req.get_url,
                          "http://metrics.example.org/v2.0/50/views/" +
                          "enum_grinder_org.example.metric.metric456?" +
@@ -752,17 +751,21 @@ class ThrottlingGroupTest(unittest.TestCase):
         # given
         times = iter(xrange(10)).next
         last_time_returned = [None]
+
         def time_source():
             # this time source returns an incrementing sequence of numbers
             # starting from zero
             t = times()
             last_time_returned[0] = t
             return t
+
         sleeps = []
+
         def sleep_source(arg):
             # this sleep source just logs what arguments were passed to it, and
             # doesn't actually sleep
             sleeps.append(arg)
+
         tg = ThrottlingGroup('test', 2, time_source=time_source,
                              sleep_source=sleep_source)
 
@@ -791,16 +794,20 @@ class ThrottlingGroupTest(unittest.TestCase):
         # given
         times = iter([0, 61]).next
         last_time_returned = [None]
+
         def time_source():
             # this time source returns a fixed sequence of numbers
             t = times()
             last_time_returned[0] = t
             return t
+
         sleeps = []
+
         def sleep_source(arg):
             # this sleep source just logs what arguments were passed to it, and
             # doesn't actually sleep
             sleeps.append(arg)
+
         tg = ThrottlingGroup('test', 2, time_source=time_source,
                              sleep_source=sleep_source)
 
@@ -841,17 +848,21 @@ class ThreadsWithThrottlingGroupTest(unittest.TestCase):
         })
         times = iter(xrange(10)).next
         last_time_returned = [None]
+
         def time_source():
             # this time source returns an incrementing sequence of numbers
             # starting from zero
             t = times()
             last_time_returned[0] = t
             return t
+
         sleeps = []
+
         def sleep_source(arg):
             # this sleep source just logs what arguments were passed to it, and
             # doesn't actually sleep
             sleeps.append(arg)
+
         tgroup = ThrottlingGroup('test', 6, time_source, sleep_source)
 
         th1 = ingest.IngestThread(0, 0, MockReq(), self.test_config, tgroup)

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -782,6 +782,7 @@ suite.addTest(loader.loadTestsFromTestCase(MakeAnnotationsIngestRequestsTest))
 suite.addTest(loader.loadTestsFromTestCase(MakeIngestRequestsTest))
 suite.addTest(loader.loadTestsFromTestCase(MakeIngestEnumRequestsTest))
 suite.addTest(loader.loadTestsFromTestCase(MakeQueryRequestsTest))
+suite.addTest(loader.loadTestsFromTestCase(ThrottlingGroupTest))
 unittest.TextTestRunner().run(suite)
 
 

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -14,6 +14,7 @@ import annotationsingest
 import abstract_thread
 import thread_manager as tm
 from config import clean_configs
+from throttling_group import ThrottlingGroup
 
 try:
     from com.xhaus.jyson import JysonCodec as json
@@ -744,6 +745,32 @@ class MakeQueryRequestsTest(TestCaseBase):
                          "from=-86399000&to=1000&resolution=FULL")
         self.assertEqual(req.post_payload, payload_sent)
         self.assertEquals((req.post_url, req.post_payload), result)
+
+
+class ThrottlingGroupTest(unittest.TestCase):
+    def test_throttling(self):
+        # given
+        tg = ThrottlingGroup('test', 2)
+        t = time.time()
+        t_plus_1 = t + 60
+
+        # when
+        tg.count_request()
+
+        # then
+        self.assertLess(time.time(), t_plus_1)
+
+        # when
+        tg.count_request()
+
+        # then
+        self.assertLess(time.time(), t_plus_1)
+
+        # when
+        tg.count_request()
+
+        # then
+        self.assertGreaterEqual(time.time(), t_plus_1)
 
 
 suite = unittest.TestSuite()

--- a/scripts/thread_manager.py
+++ b/scripts/thread_manager.py
@@ -28,7 +28,7 @@ class ThreadManager(object):
 
         self.requests_by_type = requests_by_type
 
-    def setup_thread(self, thread_num, agent_num, tgroups):
+    def setup_thread(self, thread_num, agent_num, tgroups=None):
         """Figure out which type thread to create based on thread_num and
         return it
 
@@ -90,7 +90,7 @@ class ThreadManager(object):
         if thread_type in self.requests_by_type:
             req = self.requests_by_type[thread_type]
             tgroup = None
-            if tgname and tgname in tgroups:
+            if tgname and trgoups and tgname in tgroups:
                 tgroup = tgroups[tgname]
             return thread_type(thread_num, agent_num, req, self.config, tgroup)
         else:

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -6,6 +6,15 @@ import time
 
 
 class ThrottlingGroup(object):
+
+    """Throttling groups allow you to limit the number of requests made by
+     threads. Separate threads can share a single ThrottlingGroup object, so
+     that they all count towards the limit. If a request puts a given
+     throttling group over its limit, then the thread that is trying to send
+     the request will sleep until the 1-minute interval has completed. All
+     other threads that attempt to send a request during that time will block.
+    """
+
     def __init__(self, name, max_requests_per_minute, time_source=None,
                  sleep_source=None):
 

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -36,8 +36,6 @@ class ThrottlingGroup(object):
                 self.start_time = current_time
             elif self.count < self.max_requests_per_minute:
                 self.count += 1
-                if self.start_time < 0:
-                    self.start_time = current_time
             else:
                 seconds_to_wait = self.start_time + 60 - current_time
                 if seconds_to_wait > 0:

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -51,3 +51,8 @@ class ThrottlingGroup(object):
                     self.sleep_source(seconds_to_wait)
                 self.count = 1
                 self.start_time = self.time_source()
+
+
+class NullThrottlingGroup(object):
+    def count_request(self):
+        pass

--- a/scripts/throttling_group.py
+++ b/scripts/throttling_group.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+from __future__ import with_statement
+import threading
+import time
+
+
+class ThrottlingGroup(object):
+    def __init__(self, name, max_requests_per_minute):
+        self.name = name
+        self.max_requests_per_minute = max_requests_per_minute
+        self.count = 0
+        self.lock = threading.Lock()
+        self.start_time = -1
+
+    def count_request(self):
+        with self.lock:
+            current_time = time.time()
+            seconds_since_start = current_time - self.start_time
+            if seconds_since_start >= 60:
+                self.count = 1
+                self.start_time = current_time
+            elif self.count < self.max_requests_per_minute:
+                self.count += 1
+                if self.start_time < 0:
+                    self.start_time = current_time
+            else:
+                seconds_to_wait = self.start_time + 60 - current_time
+                if seconds_to_wait > 0:
+                    time.sleep(seconds_to_wait)
+                self.count = 1
+                self.start_time = time.time()


### PR DESCRIPTION
This PR adds the `ThrottlingGroup` class, which is used to limit the number of requests sent by all threads utilizing one such object. It also adds config properties that control throttling groups and assigns them to threads.

The `properties/grinder.properties.local` file can be used as an example. It defined two throttling groups, one for ingest-type threads and one for query-type threads.

Note that enum-related threads are not assigned throttling groups, because they are planned to be removed.